### PR TITLE
fix: use `Label`s instead of strings for toolchain types

### DIFF
--- a/launcher/private/rules/lib.bzl
+++ b/launcher/private/rules/lib.bzl
@@ -1,4 +1,6 @@
-_FINALIZER_TOOLCHAIN_TYPE = "@hermetic_launcher//launcher:finalizer_toolchain_type"
+_FINALIZER_TOOLCHAIN_TYPE = Label("//launcher:finalizer_toolchain_type")
+_TEMPLATE_TOOLCHAIN_TYPE = Label("//launcher:template_toolchain_type")
+_TEMPLATE_EXEC_TOOLCHAIN_TYPE = Label("//launcher:template_exec_toolchain_type")
 
 def _get_finalizer(ctx):
     toolchain = ctx.toolchains[_FINALIZER_TOOLCHAIN_TYPE]
@@ -9,9 +11,9 @@ def _get_template(ctx, *, cfg = "target", template_exec_group = None, template_f
         return template_file
     toolchain_dict = ctx.toolchains if template_exec_group == None else ctx.exec_groups[template_exec_group].toolchains
     if cfg == "target":
-        toolchain = toolchain_dict["@hermetic_launcher//launcher:template_toolchain_type"]
+        toolchain = toolchain_dict[_TEMPLATE_TOOLCHAIN_TYPE]
     elif cfg == "exec":
-        toolchain = toolchain_dict["@hermetic_launcher//launcher:template_exec_toolchain_type"]
+        toolchain = toolchain_dict[_TEMPLATE_EXEC_TOOLCHAIN_TYPE]
     else:
         fail("Invalid cfg '%s': must be 'target' or 'exec'" % cfg)
     return toolchain.templatetoolchaininfo.template_exe
@@ -122,6 +124,6 @@ launcher = struct(
     append_raw_transformed_arg = _append_raw_transformed_arg,
     compile_stub = _compile_stub,
     finalizer_toolchain_type = _FINALIZER_TOOLCHAIN_TYPE,
-    template_toolchain_type = "@hermetic_launcher//launcher:template_toolchain_type",
-    template_exec_toolchain_type = "@hermetic_launcher//launcher:template_exec_toolchain_type",
+    template_toolchain_type = _TEMPLATE_TOOLCHAIN_TYPE,
+    template_exec_toolchain_type = _TEMPLATE_EXEC_TOOLCHAIN_TYPE,
 )


### PR DESCRIPTION
using string-form Labels with `ctx.actions.run(toolchain = ...)` in the `launcher` helpers requires that the caller of such helpers have `hermetic_launcher` in their repo mapping

in general this may not be true:
  1. direct rdeps of `hermetic_launcher` may have assigned it a different `repo_name`
  2. indirect rdeps of `hermetic_launcher` may not have it in their repo mapping at all
      + for example, `aspect_rules_py` uses `hermetic_launcher` in its [`py_venv_exec` rule](https://github.com/aspect-build/rules_py/blob/dec1bc1ecb3275c1684ffad509151e6875981e5d/py/private/py_venv/py_venv_exec.bzl#L86-L110)
      + users of `aspect_rules_py` may not have `hermetic_launcher` in their repo mapping

(2) results in errors like so, **with `--incompatible_auto_exec_groups`**:
```console
File "/.../external/hermetic_launcher+/launcher/private/rules/lib.bzl", line 52, column 20, in _compile_stub
    ctx.actions.run(
Error in run: Action declared for non-existent toolchain '@@[unknown repo 'hermetic_launcher' requested from @@top+]//launcher:finalizer_toolchain_type'.
```

to fix this, this PR switches to using `Label` for toolchain types in `@hermetic_launcher//launcher/private/rules:lib.bzl`; this eagerly resolves the toolchain type string-form labels using `hermetic_launcher`'s repo mapping

---

re (2): this is arguably a bug in Bazel; unlike `ctx.toolchains["..."]` which [resolves][toolchains_res] string-form Labels using the repo mapping corresponding to the [repo where the `.bzl` file doing the access lives][forBzlEvalThread], `ctx.actions.run` [resolves][run_res] string-form `Label`s in its `toolchain` argument using the [repo mapping corresponding to the repo the _rule_][packageContext] that was being analyzed was defined in

[toolchains_res]: https://github.com/bazelbuild/bazel/blob/009ea69934c0c87ff15336cd923183c44de4b031/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkToolchainContext.java#L106
[forBzlEvalThread]: https://github.com/bazelbuild/bazel/blob/59cb6fe990933eb764fd22ef3115c0d7f51baded/src/main/java/com/google/devtools/build/lib/packages/LabelConverter.java#L35-L44

[run_res]: https://github.com/bazelbuild/bazel/blob/731c243029244400bbb91a36e77cc92a17df497a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java#L870-L872
[packageContext]: https://github.com/bazelbuild/bazel/blob/5fbb25a42d7100ef6bf4c6d82f165fb23786b425/src/main/java/com/google/devtools/build/lib/cmdline/Label.java#L210-L220

I'll file a bug in Bazel about this but I still think it's worth accepting this PR to address scenario (1).